### PR TITLE
Build exe

### DIFF
--- a/build.nix
+++ b/build.nix
@@ -110,7 +110,7 @@ stdenv.mkDerivation ({
 
     (
     set -x
-    pub get --no-precompile --offline
+    dart pub get --no-precompile --offline
     ${buildSnapshots}
     )
 

--- a/build.nix
+++ b/build.nix
@@ -3,7 +3,6 @@
 , stdenv
 , dart
 , fetchzip
-, makeWrapper
 , runCommand
 }:
 
@@ -93,7 +92,10 @@ in
 stdenv.mkDerivation ({
   PUB_CACHE = "${pubCache}";
 
-  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ makeWrapper dart ];
+  # Dart binaries are broken if stripped
+  dontStrip = true;
+
+  nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ dart ];
 
   buildInputs = (args.buildInputs or [ ]);
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1652133925,
-        "narHash": "sha256-kfATGChLe9/fQVZkXN9G71JAVMlhePv1qDbaRKklkQs=",
+        "lastModified": 1679319606,
+        "narHash": "sha256-wyEMIZB6BnsmJWInEgDZu66hXVMGJEZFl5uDsn27f9M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51d859cdab1ef58755bd342d45352fc607f5e59b",
+        "rev": "8bc6945b1224a1cfa679d6801580b1054dba1a5c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This will build the self-contained exes, removing the dependency on dart in runtime (and making the output derivation so much smaller!)

This is rebased over https://github.com/tadfisher/nix-dart/pull/9.